### PR TITLE
Skip nvm aliases in Travis CI rule

### DIFF
--- a/rules/travis.js
+++ b/rules/travis.js
@@ -3,6 +3,7 @@ const semver = require('semver');
 
 const SUPPORTED_VERSIONS = ['0.10', '0.12', '4', '6'];
 const DEPRECATED_VERSIONS = ['iojs', 'stable', 'unstable'];
+const IGNORED_VERSIONS = ['node', 'lts/*', 'lts/argon', 'lts/boron'];
 
 /**
  * Normalize a semantic version to be a valid version. 0.10 -> 0.10.0
@@ -74,22 +75,28 @@ module.exports = ctx => {
 				});
 			}
 
-			const versions = Array.isArray(travis.node_js) ? travis.node_js : [travis.node_js];
+			let versions = Array.isArray(travis.node_js) ? travis.node_js : [travis.node_js];
 
-			for (const version of versions) {
-				if (DEPRECATED_VERSIONS.indexOf(version) !== -1) {
+			versions = versions.filter(version => {
+				if (IGNORED_VERSIONS.indexOf(version) !== -1) {
+					return false;
+				} else if (DEPRECATED_VERSIONS.indexOf(version) !== -1) {
 					ctx.report({
 						message: `Version \`${version}\` is deprecated.`,
 						file
 					});
-				} else if (version !== 'node' && engine && !semver.satisfies(normalize(version), engine)) {
+
+					return false;
+				} else if (engine && !semver.satisfies(normalize(version), engine)) {
 					ctx.report({
 						message: `Unsupported version \`${version}\` is being tested.`,
 						fix: fixers.unsupported(version),
 						file
 					});
 				}
-			}
+
+				return true;
+			});
 
 			if (engine) {
 				for (const version of SUPPORTED_VERSIONS) {

--- a/rules/travis.js
+++ b/rules/travis.js
@@ -2,7 +2,7 @@
 const semver = require('semver');
 
 const SUPPORTED_VERSIONS = ['0.10', '0.12', '4', '6'];
-const DEPRECATED_VERSIONS = ['iojs', 'stable'];
+const DEPRECATED_VERSIONS = ['iojs', 'stable', 'unstable'];
 
 /**
  * Normalize a semantic version to be a valid version. 0.10 -> 0.10.0

--- a/test/fixtures/travis/aliases/.travis.yml
+++ b/test/fixtures/travis/aliases/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - 'node'
+  - 'lts/*'
+  - 'lts/argon'
+  - 'lts/boron'
+  - '6'
+  - '4'

--- a/test/fixtures/travis/aliases/package.json
+++ b/test/fixtures/travis/aliases/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "travis",
+  "engines": {
+    "node": ">=4"
+  }
+}

--- a/test/fixtures/travis/deprecated/.travis.yml
+++ b/test/fixtures/travis/deprecated/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 'stable'
+  - 'unstable'
   - 'iojs'
   - '0.12'
   - '0.10'

--- a/test/travis.js
+++ b/test/travis.js
@@ -106,6 +106,10 @@ test('untested versions', async t => {
 	);
 });
 
+test('aliases', async t => {
+	await ruleTester(t, 'aliases', []);
+});
+
 test('deprecated versions', async t => {
 	const file = path.resolve(opts.cwd, 'deprecated/.travis.yml');
 

--- a/test/travis.js
+++ b/test/travis.js
@@ -118,6 +118,12 @@ test('deprecated versions', async t => {
 				severity: 'error'
 			},
 			{
+				message: 'Version `unstable` is deprecated.',
+				file,
+				ruleId: 'travis',
+				severity: 'error'
+			},
+			{
 				message: 'Version `iojs` is deprecated.',
 				file,
 				ruleId: 'travis',


### PR DESCRIPTION
When running clinton against a package with an `engines` field and `node` in `.travis.yml` it crashes with `TypeError: Invalid Version: node.0.0`. A similar error was already reported in #46.

With this change it now skips all nvm aliases in `isSupported()`. It still crashes when using the `unstable` alias but I suggest resolving this by adding `unstable` to the list of deprecated versions.